### PR TITLE
feature extractor now combines mult features, including sentiment ones!

### DIFF
--- a/Code/feature_extractor.py
+++ b/Code/feature_extractor.py
@@ -1,21 +1,54 @@
 # Imports
 from sklearn.feature_extraction.text import CountVectorizer
+from sklearn.naive_bayes import MultinomialNB
+import os
+import numpy as np
+from scipy.sparse import hstack
+from sent_analysis import SentimentClassifier
 
 class FeatureExtractor():
     """ A class to extract text features """
-    def __init__(self, arg):
-        self.arg = arg
+    def __init__(self):
+        # A mapping of keywords to functions (for use in extract features)
+        self.features_dict = {'unary': self.unary_features, 'sent_analysis': self.sent_analysis}
 
     def unary_features(self, data):
         count_vect = CountVectorizer()
         return count_vect.fit_transform(data)
         
-    def sent_analysis(self, data):
+    def sent_analysis(self, data, sent_pred_func):
         """ Extracts Sentiment Analysis Features via sent_analysis.py """
-        pass
+        # Possible TODO: can move sent_clf to be an instance variable... I think it's cleaner
+        # to have it isolated here, BUT if we end up calling sent_analysis mult times, then 
+        # it will retrain sent_clf each time... (not an issue if this func used once)
+        clf = MultinomialNB()
+        sent_clf = SentimentClassifier(sent_pred_func, os.path.join('..', 'Data', 'sent140', 'raw'), clf)
+        return sent_clf.fit_and_predict(data)
 
-    def extract_features(self, data, feat_types):
-        """ External function to call to extract multiple features"""
+    def extract_features(self, data, features_to_extract):
+        """ External function to call to extract multiple features 
 
-        #thought: you'd pass [unary, binary] and extract and return both
+            ie:
+                features_to_extract = ['unary', ('sent_analysis', 'baseline')]
+                would be 'unary' feats on data AND 'sent_analysis' of type 'baseline' on data
+        """
+        feats_not_initialized = True
+        for feat in features_to_extract:
+            print "Extracting feature", feat
+            if type(feat) is tuple:
+                #if its a tuple interpret it as a function name and args!
+                if feats_not_initialized:
+                    features = self.features_dict[feat[0]](data, *feat[1:])
+                    feats_not_initialized = False
+                else:
+                    new_feats = self.features_dict[feat[0]](data, *feat[1:])
+                    features = hstack((features, new_feats))
 
+            else:
+                if feats_not_initialized:
+                    features = self.features_dict[feat](data)
+                    feats_not_initialized = False
+                else:
+                    features = hstack((features, self.features_dict[feat](data)))
+
+        return features

--- a/Code/run_me.py
+++ b/Code/run_me.py
@@ -86,8 +86,8 @@ else:
 
 # Extract Features
 verboseprint("Extracting features...")
-extractor = feature_extractor.FeatureExtractor(1)
-x_counts = extractor.unary_features(data)
+extractor = feature_extractor.FeatureExtractor()
+x_counts = extractor.extract_features(data, ['unary', ('sent_analysis', 'baseline')])
 verboseprint("Features shape: ", x_counts.shape)
 # print count_vect.vocabulary_
 verboseprint("*******")

--- a/Code/sent_analysis.py
+++ b/Code/sent_analysis.py
@@ -5,13 +5,26 @@ from sklearn.feature_extraction.text import CountVectorizer
 from load_data import load_sent140
 
 class SentimentClassifier():
-    def __init__(self, data_path, model):
+    def __init__(self, pred_func, data_path, model):
+        # Data related vars
         self.trdata = None
         self.tedata = None
         self.trlabels = None
         self.telabels = None
         self.data_path = data_path
+
+        # Prediction related features
         self.model = model
+
+        #use for a mapping of what prediction func to use!
+        self.pred_dict = {'baseline': self.fit_and_predict_baseline}
+        self.pred_func_name = pred_func
+
+
+    def fit_and_predict(self, data):
+        """ Prediction wrapper that uses self.type_dict and self.type to call the right prediction function """
+        print "Using SentimentClassifier to predict sentiment using the function ", self.pred_func_name
+        return self.pred_dict[self.pred_func_name](data)
 
     def load_data(self):
         """ A function to load data for the sentiment classifier 
@@ -23,7 +36,9 @@ class SentimentClassifier():
         self.trdata, self.trlabels, self.tedata, self.telabels = load_sent140(self.data_path)
 
     def fit_and_predict_baseline(self, data):
-        """ Fit for baseline sentiment scores and predict on incoming data """
+        """ Fit for baseline sentiment scores and predict on incoming data 
+            DON'T CALL DIRECTLY, USE `fit_and_predict`
+        """
         # Fit to training data
         count_vect = CountVectorizer()
         if self.trdata is None:
@@ -35,4 +50,5 @@ class SentimentClassifier():
         # Use fit model to predict on data:
         # transform data
         counts = count_vect.transform(data)
-        return self.model.predict(counts)
+        preds = self.model.predict(counts) #numpy array
+        return preds.reshape(len(preds), 1) #numpy nx1 column


### PR DESCRIPTION
# Big updates wooooo!

### Biggest Idea:
**What:** Use a dictionary to map between strings and functions
**Why:** I want "wrapper" functions to abstract what happens underneath. ie: I want to extract unary and baseline sentiment features. Instead of knowing which methods to call, I should simply be able to call `FeatureExtractor.extract_features(data, ['unary', ('sent_analysis', 'baseline')]) ` and this will do the heavy lifting, combine the features, and return one array for our use.


### How used / where:
In `FeatureExtractor`, the wrapper method is `extract_features` and it takes in the data to extract features for (simply a list of strings) as well as a list of features to extract. The list contain:

1. Strings: these indicate a single function call on data
2. Tuples: these are a string (the function) and all other parts of the tuple are params for the function

The mapping between strings-> function names happens as the `self.features_dict` in FeatureExtractor.



A very similar style is used in `SentimentClassifier`, which has one `fit_and_predict` function which takes in the type of sentiment analysis to do (a string which maps to `pred_dict` for prediction dictionary). The only option currently is `'baseline'`, however in the future we may have many combinations!


Feel free to reach out w qus.
Cheers,
Alex