### PR TITLE
Pickles in the Run Me

### DIFF
--- a/Code/.gitignore
+++ b/Code/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 CMUTweetTagger.py
 ark-tweet-nlp-0.3.2/
+*.pkl

--- a/Code/run_me.py
+++ b/Code/run_me.py
@@ -19,7 +19,9 @@ from parse_loadout import parse_loadout as pl
 import time
 import re
 from pos_tagger import pos_tag
+import pickle
 import unicodedata
+from sent_predictor import predict_sent
 if os.name != 'nt':
     from spell_checker import correct_spelling
 
@@ -201,14 +203,25 @@ if 'pos-tags' in pre:
 #               EXTRACT FEATURES
 # ##############################################
 
-verboseprint("Extracting features...")
+verboseprint("*******")
+verboseprint("Loading pickled sentiment classifiers...")
+with open('sent.pkl', 'r') as f:
+    clf, clf_name, pickleables, perm = pickle.load(f)
+
+verboseprint("The best sent_clf stored is: %s with feats %s"
+             % (clf_name, perm))
+
+clf_feats = predict_sent(data, clf, clf_name, pickleables, perm)
+verboseprint("Sentiment prediction features complete")
+verboseprint("*******")
+
+verboseprint("Extracting text features...")
 extractor = TextFeatureExtractor()
 feats = extractor.extract_features(data, ftyps, cvargs)
 
-# TODO : reconnect the sentiment classifiers! Load in from pickle!
 
 # Use Combinator to Combine Features
-combinator = FeatureCombinator(feats)
+combinator = FeatureCombinator(feats, clf_feats)
 
 
 # ##############################################

--- a/Code/send_it.py
+++ b/Code/send_it.py
@@ -10,6 +10,8 @@ from sklearn.naive_bayes import MultinomialNB
 from load_data import load_sent140
 from sklearn.model_selection import train_test_split
 import os
+import pickle
+from sklearn.externals import joblib
 
 # ##############################################
 #               ARGUMENT PROCESSING
@@ -140,3 +142,12 @@ print "Best overall: %s with %s giving score %f" % \
 clfs[best['clf']].fit(best['perm'][1], y_train)
 
 # Store the Classifiers in Pickle
+# Pickle the following:
+#     1. The trained classifier
+#     2. The FE used (with its CV's and all) for re-extraction on pred data
+#     3. The feat_perm list of feats for re-extraction on prediction data
+clf_name = best['clf']
+to_pikle = (clfs[clf_name], clf_name, fe.get_pickleables(), best['perm'][0])
+
+with open('sent.pkl', 'w') as f:
+    pickle.dump(to_pikle, f)

--- a/Code/sent_predictor.py
+++ b/Code/sent_predictor.py
@@ -1,0 +1,27 @@
+from text_feat_extractor import TextFeatureExtractor
+from scipy.sparse import hstack
+
+
+def predict_sent(data, clf, clf_name, pickleables, perm):
+    """ Given pickle stuff, return sent prediction on data """
+
+    # Create new FE
+    fe = TextFeatureExtractor()
+
+    # Use FE w Pickleables to extract data on `data`
+    feats_to_extract = list(perm)
+    feats = fe.extract_features(data, feats_to_extract, pickles=pickleables)
+
+    # Stack all feats (kinda like a 1-shot FC)
+    feat_keys = feats.keys()
+    full_feats = feats[feat_keys[0]]
+
+    for k in feat_keys[1:]:
+        full_feats = hstack((full_feats, feats[k]))
+
+    # Use pretrained clf to predict on feats
+    preds = clf.predict(full_feats).reshape(-1, 1)
+
+    # TODO: maybe adapt to be a dict of more than one clf?
+    # FC is adaptable to this, would just need to pickle more than one!
+    return {clf_name: preds}

--- a/Code/text_feat_extractor.py
+++ b/Code/text_feat_extractor.py
@@ -1,6 +1,6 @@
 # Imports
 from sklearn.feature_extraction.text import CountVectorizer
-import CMUTweetTagger
+# import CMUTweetTagger
 
 
 class TextFeatureExtractor():
@@ -10,32 +10,52 @@ class TextFeatureExtractor():
         self.features_dict = {'unigram': self.unigram_features,
                               'bigram': self.bigram_features}
 
-    def unigram_features(self, data, cvargs):
-        if cvargs is not None:
-            count_vect = CountVectorizer(
-                lowercase=cvargs['lowercase'],
-                stop_words=cvargs['stop_words'],
-                strip_accents=cvargs['strip_accents'],
-                token_pattern=cvargs['token_pattern']
-            )
-        else:
-            count_vect = CountVectorizer()
-        return count_vect.fit_transform(data)
+        # A list of the CV's trained (for pickling)
+        self.pickleables = {}
 
-    def bigram_features(self, data, cvargs):
-        if cvargs is not None:
-            count_vect = CountVectorizer(
-                ngram_range=(2, 2),
-                lowercase=cvargs['lowercase'],
-                stop_words=cvargs['stop_words'],
-                strip_accents=cvargs['strip_accents'],
-                token_pattern=cvargs['token_pattern']
-            )
-        else:
-            count_vect = CountVectorizer(ngram_range=(2, 2))
-        return count_vect.fit_transform(data)
+    def unigram_features(self, data, cvargs, pickles):
+        if pickles is None:
+            if cvargs is not None:
+                count_vect = CountVectorizer(
+                    lowercase=cvargs['lowercase'],
+                    stop_words=cvargs['stop_words'],
+                    strip_accents=cvargs['strip_accents'],
+                    token_pattern=cvargs['token_pattern']
+                )
+            else:
+                count_vect = CountVectorizer()
 
-    def extract_features(self, data, features_to_extract, cvargs=None):
+            counts = count_vect.fit_transform(data)
+            self.pickleables['unigram'] = count_vect  # store after fitting
+
+        else:
+            counts = pickles['unigram'].transform(data)
+
+        return counts
+
+    def bigram_features(self, data, cvargs, pickles):
+        if pickles is None:
+            if cvargs is not None:
+                count_vect = CountVectorizer(
+                    ngram_range=(2, 2),
+                    lowercase=cvargs['lowercase'],
+                    stop_words=cvargs['stop_words'],
+                    strip_accents=cvargs['strip_accents'],
+                    token_pattern=cvargs['token_pattern']
+                )
+            else:
+                count_vect = CountVectorizer(ngram_range=(2, 2))
+
+            counts = count_vect.fit_transform(data)
+            self.pickleables['bigram'] = count_vect  # store after fitting
+
+        else:
+            counts = pickles['bigram'].transform(data)
+
+        return counts
+
+    def extract_features(self, data, features_to_extract,
+                         cvargs=None, pickles=None):
         """ External function to call to extract multiple features
 
             ie:
@@ -46,6 +66,13 @@ class TextFeatureExtractor():
         features = {}
         for feat in features_to_extract:
             print "Extracting feature", feat
-            features[feat] = self.features_dict[feat](data, cvargs)
+            features[feat] = self.features_dict[feat](data, cvargs, pickles)
 
         return features
+
+    def get_pickleables(self):
+        """ Returns the parts of TFE needed to pickle
+
+            Currently this is only a list of the fitted CV's used!
+        """
+        return self.pickleables


### PR DESCRIPTION
**Its gettin salty!**

## Quick run(me)-down:

1. send_it saves the best (and only the best) clf to do this it saves:
1.1 the trained classifier
1.2 the classifier name (for the key in the feat dict)
1.3 the "pickleables" (parts of FE that must individually be pickled--currently only the CV instances)
1.4 the winning perm combo

2. In run_me the pickle is loaded and unpacked and sent to a new file `sent_predictor`
3. In sent_predictor, a new FE is made and used with the pickleables to extract the same dimensional features that the clf was trained on. 
4. the sent_predictor sends back the dict {'clf_name': pred_feats} that can be tossed right away into FC
5. FC takes it away and the rest is history!

## Changes to FE
One of the bigger changes to the pipeline was the FE.extract_features can now be given "pickleables", namely the CV instances that were used in a past FE instance (this necessary since FE was being tough about being pickled...)

FE's unary and binary extraction methods now take in a parameter for pickles, which would be a fitted CV instance (namely the one saved in the pickle). If present, it will use that instead of training a new one.

In this way, FE can be used to completely extract new feats, or extract old feats!

